### PR TITLE
Cache vcpkg dependencies on GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,13 +19,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
       - name: Install vcpkg dependencies
         if: runner.os == 'Windows'
         run: |
           cargo install cargo-vcpkg
           cargo vcpkg build
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
       - name: Typecheck
         run: cargo check --all-targets --all-features
       - name: Clippy


### PR DESCRIPTION
Cache vcpkg dependencies on GitHub Actions. Should reduce time spent in CI.