### PR TITLE
Timeout for CI testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
GitHub Actions has a timeout of 360 minutes by default. This is way too long to see a failure and it eats into our precious quota. Tests in CI now timeout at 10 minutes, which is around ~5 minutes longer than the expected runtime.